### PR TITLE
Update version number due to breaking change

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule TypedStructEctoChangeset.MixProject do
   def project do
     [
       app: :typed_struct_ecto_changeset,
-      version: "0.3.0",
+      version: "1.0.0",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
The plugin interface of the new version of `typed_struct` introduces a potentially breaking change to client plugins

Update this library's version number to indicate that possibility