### PR TITLE
Fix dependency requirement and add more documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,43 @@
 # TypedStructEctoChangeset
 
-TypedStruct plugin to integrate ecto changeset, allow
-to use typedstruct module like ecto schema module when casting
-changeset, embeds and assoc are not yet supported
+A [plugin](https://hexdocs.pm/typed_struct/TypedStruct.Plugin.html)
+to enable basic "embeds"
+[Ecto.cast](https://hexdocs.pm/ecto/Ecto.Changeset.html#cast/4) support to the 
+module created by the containing
+[TypedStruct](https://hexdocs.pm/typed_struct/TypedStruct.html) macro.
+
+## Example
+
+If this module is defined:
+  ```elixir
+  defmodule TypedStructModule do
+    use TypedStruct
+
+    typedstruct do
+      plugin TypedStructEctoChangeset
+
+      field :age, integer()
+      field :name, String.t()
+    end
+  end
+  ```
+Then we can:
+
+      iex> Ecto.Changeset.cast(%TypedStructModule{}, %{"age" => 23, "name" => "John Doe"}, [:age, :name])
+      %Ecto.Changeset{}
+
+## Limitations
+
+More database-centric fields such as [assoc](https://hexdocs.pm/ecto/Ecto.Changeset.html#cast_assoc/3) are not yet 
+supported
 
 ## Installation
+
+Because this plugin supports the interface defined by the `TypedStruct` macro, installation assumes you've already
+added that dependency.
+
+While you can use the original [typed_struct](https://hex.pm/packages/typed_struct) library, it seems to no longer be 
+maintained.  However, there is a fork [here](https://hex.pm/packages/typedstruct) that is quite active.
 
 If [available in Hex](https://hex.pm/docs/publish), the package can be installed
 by adding `typed_struct_ecto_changeset` to your list of dependencies in `mix.exs`:
@@ -12,7 +45,15 @@ by adding `typed_struct_ecto_changeset` to your list of dependencies in `mix.exs
 ```elixir
 def deps do
   [
-    {:typed_struct_ecto_changeset, "~> 0.1.0"}
+    # Choose either of the following `TypedStruct` libraries
+    # The original TypedStruct library
+    {:typed_struct, "~> 0.3.0"},
+      
+    # Or the newer forked TypedStruct library
+    {:typedstruct, "~> 0.5.2"},
+
+    # And add this library  
+    {:typed_struct_ecto_changeset, "~> 1.0.0"}
   ]
 end
 ```
@@ -20,4 +61,3 @@ end
 Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
 and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
 be found at [https://hexdocs.pm/typed_struct_ecto_changeset](https://hexdocs.pm/typed_struct_ecto_changeset).
-

--- a/mix.exs
+++ b/mix.exs
@@ -42,7 +42,7 @@ defmodule TypedStructEctoChangeset.MixProject do
       {:dialyxir, "~> 1.3", only: [:dev], runtime: false},
       {:ecto, "~> 3.10", only: [:test]},
       {:ex_doc, "~> 0.29", only: [:dev], runtime: false},
-      {:typed_struct, "~> 0.3.0"}
+      {:typed_struct, "~> 0.3.0", only: [:dev], runtime: false}
     ]
   end
 end


### PR DESCRIPTION
Because this plugin just supports the interface defined by `TypedStruct`, we don't actually have to require a specific version of the calling library.

Which is good because the original library seems to have become stale and the author has not responded to requests to add maintainers.

This PR removes that dependency requirement, and adds documentation about installation and basic usage